### PR TITLE
AddItems structure fix

### DIFF
--- a/lib/src/hal-resource.js
+++ b/lib/src/hal-resource.js
@@ -115,9 +115,7 @@ const HalResource = (existingRepresentation) => {
   const addItem = (item = {}) => {
     item.href || requiredParam("href");
     createItemsArray();
-    resourceRepresentation._links.item.push({
-      item,
-    });
+    resourceRepresentation._links.item.push(item);
   };
 
   const addItems = (itemsArray = []) => {


### PR DESCRIPTION
Fixing the Item link structure. The AddItem function was adding a redundant 'Item' attribute to the item object. Example: 

 "_links": {
        "item": [
          {
            **"item": {**
              "summary": {
                "customer": "dxc",
                "account": "11111",
                "region": "us-west-2",
                "environment": "scratch-2",
                "cidr_ip": "10.0.16.0",
                "cidr_mask": 20
              },
              "href": "https://assure.proxy.lambda/customer=dxc,account=11111,region=us-west-2,environment=scratch-2",
              "title": "CIDR-Block"
            }
          }
        ],