### PR TITLE
createItemsArray() in AddItems

### DIFF
--- a/lib/src/hal-resource.js
+++ b/lib/src/hal-resource.js
@@ -119,6 +119,7 @@ const HalResource = (existingRepresentation) => {
   };
 
   const addItems = (itemsArray = []) => {
+    createItemsArray();
     itemsArray.forEach((item) => {
       addItem(item);
     });


### PR DESCRIPTION
We need to create the Items link even if the list of items is empty, so the link is present in the resource response. 