### PR TITLE
Fixed bug with empty headers

### DIFF
--- a/lib/src/response/service/hal-response-service.js
+++ b/lib/src/response/service/hal-response-service.js
@@ -12,7 +12,9 @@ export function getType({ headers } = {}) {
 }
 
 export function containsHalResource({ headers } = {}) {
-  return (headers[CONTENT_TYPE].includes(HAL_JSON) || headers[CONTENT_TYPE].includes(HAL_JSON2))
-    ? true
-    : headers[CONTENT_LOCATION] && headers[LOCATION] && headers[CONTENT_LOCATION] === headers[LOCATION];
+  return headers && headers[CONTENT_TYPE] ? 
+    (headers[CONTENT_TYPE].includes(HAL_JSON) || headers[CONTENT_TYPE].includes(HAL_JSON2)) ? 
+      true
+      : headers[CONTENT_LOCATION] && headers[LOCATION] && headers[CONTENT_LOCATION] === headers[LOCATION]
+    : false;
 }


### PR DESCRIPTION
When an empty response is received, the library does not work and causes some UIs to not work as expected.
This case was found when doing a DELETE operation and receiving an empty response with code 204.